### PR TITLE
Bypass pagination

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,7 @@ celerybeat-schedule
 # virtualenv
 .venv
 venv/
+myvenv/
 ENV/
 
 # Spyder project settings

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ pip install -r requirements.txt
 ```
 
 ```python
-from adapters.github import GithubAdapter
+from adapters.github import GitHubAdapter
 
 client = GithubAdapter(oauth_token="[insert_token_here]")
 ```

--- a/adapters/github.py
+++ b/adapters/github.py
@@ -85,8 +85,12 @@ class GitHubAdapter:
     def _get_all_items(self, url: str, *, max_pages: int = 5) -> List[Dict]:
         resp = self._head(url)
         headers = resp.headers
-        nav = create_github_navigation_panel(headers["Link"])
-        last_page = page_from_url(nav.last_link)
+
+        try:
+            nav = create_github_navigation_panel(headers["Link"])
+            last_page = page_from_url(nav.last_link)
+        except KeyError:
+            last_page = 1
 
         all_items = []
         for page_num in range(1, min(last_page, max_pages) + 1):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-dateutil
+python-dateutil
 pytz
 requests

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,0 +1,3 @@
+ipython
+pytest
+pdbpp


### PR DESCRIPTION
In `_get_all_items()`, `headers['Link']` did not exist when user's items fit on a single page, causing an exception. I added exception handling for that case such that the only page of content will be successfully returned.